### PR TITLE
Rename createSyncRoot to createBlockingRoot

### DIFF
--- a/apis/roots.md
+++ b/apis/roots.md
@@ -9,7 +9,7 @@ These are concurrent-ready attachment points for React onto the DOM.
 
 ## `ReactDOM.createRoot and Root.render`
 
-API: `ReactDOM.unstable_createRoot`
+API: `ReactDOM.createRoot`
 
 Instead of `ReactDOM.render`, `ReactDOM.createRoot` creates a Concurrent root for React. It also doesn't assume the first render is synchronous (aka you can suspend even on the first render, which useful for prerendering via `root.createBatch()`).
 
@@ -21,16 +21,16 @@ const root = ReactDOM.createRoot(container);
 root.render(<App />);
 ```
 
-## `ReactDOM.createSyncRoot`
+## `ReactDOM.createBlockingRoot`
 
-API: `ReactDOM.unstable_createSyncRoot`
+API: `ReactDOM.createBlockingRoot
 
 Create a Batched Mode root. It does not support `createBatch`.
 
 
 ```js
 const container = document.getElementById('root');
-const root = ReactDOM.createSyncRoot(container);
+const root = ReactDOM.createBlockingRoot(container);
 root.render(<App />);
 ```
 


### PR DESCRIPTION
- **createSyncRoot** was renamed to **createBlockingRoot** in [#17165](https://github.com/facebook/react/pull/17165)
- **unstable_** prefix is not necessary in experimental releases. See [#17146](https://github.com/facebook/react/pull/17146) and [#17108](https://github.com/facebook/react/pull/17108)